### PR TITLE
Fixes #1 계좌 예수금 조회 오류 수정

### DIFF
--- a/pyheroapi/client.py
+++ b/pyheroapi/client.py
@@ -2411,18 +2411,49 @@ class KiwoomClient:
         journal_data = response.get("data", [])
         return [TradingJournal(**item) for item in journal_data]
 
-    def get_deposit_details(self) -> "DepositDetail":
+    def get_deposit_details(self, query_type: str = "2") -> "DepositDetail":
         """
         Get deposit detail status (kt00001).
+
+        Args:
+            query_type: Query type ("2": general inquiry, "3": estimated inquiry)
 
         Returns:
             DepositDetail data
         """
         from .models import DepositDetail
 
-        response = self._make_request("/api/dostk/acnt", "kt00001", {})
+        data = {"qry_tp": query_type}
+        response = self._make_request("/api/dostk/acnt", "kt00001", data)
         return DepositDetail(**response)
 
+    def get_account_balance(self, account_number: str) -> "AccountBalance":
+        """
+        Get account balance information.
+
+        Args:
+            account_number: Account number
+
+        Returns:
+            AccountBalance data
+        """
+        from .models import AccountBalance
+
+        deposit_details = self.get_deposit_details()
+
+        # Calculate total balance (deposit + collateral)
+        entr = float(deposit_details.entr) if deposit_details.entr else 0.0
+        repl_amt = float(deposit_details.repl_amt) if deposit_details.repl_amt else 0.0
+        total_balance = entr + repl_amt
+
+        return AccountBalance(
+            account_number=account_number,
+            total_balance=str(int(total_balance)),
+            available_balance=deposit_details.ord_alow_amt,
+            securities_balance=deposit_details.crd_set_grnta,
+            deposit=deposit_details.entr,
+            substitute=deposit_details.repl_amt
+        )
     def get_daily_estimated_deposit_assets(self, date: str) -> Dict[str, Any]:
         """
         Get daily estimated deposit asset status (kt00002).
@@ -3011,10 +3042,10 @@ class KiwoomClient:
     # Short Selling Methods (공매도)
 
     def get_short_selling_trend(
-        self, 
-        symbol: str, 
-        time_type: str = "1", 
-        start_date: str = "", 
+        self,
+        symbol: str,
+        time_type: str = "1",
+        start_date: str = "",
         end_date: str = ""
     ) -> List[Dict[str, Any]]:
         """
@@ -3178,8 +3209,8 @@ class KiwoomClient:
         return response.get("sec_lend_bal_top10", [])
 
     def get_securities_lending_details(
-        self, 
-        symbol: str, 
+        self,
+        symbol: str,
         date_type: str = "1",
         start_date: str = "",
         end_date: str = ""
@@ -3226,7 +3257,7 @@ class KiwoomClient:
     def get_sector_investor_net_buying(
         self,
         market_type: str = "0",
-        amount_quantity_type: str = "0", 
+        amount_quantity_type: str = "0",
         base_date: str = "",
         exchange_type: str = "3"
     ) -> List[Dict[str, Any]]:
@@ -3787,5 +3818,5 @@ class KiwoomClient:
             "stex_tp": stex_tp,
             **kwargs
         }
-        
+
         return self._make_request("ka90002", "/api/dostk/thme", data)

--- a/pyheroapi/models.py
+++ b/pyheroapi/models.py
@@ -142,6 +142,7 @@ class AccountBalance(BaseModel):
     account_number: str = Field(..., description="계좌번호")
     total_balance: Optional[str] = Field(None, description="총잔고")
     available_balance: Optional[str] = Field(None, description="주문가능금액")
+    securities_balance: Optional[str] = Field(None, description="유가증권평가금액")
     deposit: Optional[str] = Field(None, description="예수금")
     substitute: Optional[str] = Field(None, description="대용금")
 

--- a/pyheroapi/models.py
+++ b/pyheroapi/models.py
@@ -356,14 +356,16 @@ class TradingJournal(BaseModel):
 
 
 class DepositDetail(BaseModel):
-    """Deposit detail model"""
+    """Deposit detail model (kt00001 response)"""
 
-    tot_evla_amt: Optional[str] = None
-    scts_evla_amt: Optional[str] = None
-    tot_dncl_amt: Optional[str] = None
-    nxdy_excc_amt: Optional[str] = None
-    nxdy_auto_rdpt_amt: Optional[str] = None
-    ord_psbl_cash: Optional[str] = None
+    entr: Optional[str] = Field(None, description="예수금")
+    ord_alow_amt: Optional[str] = Field(None, description="주문가능금액")
+    pymn_alow_amt: Optional[str] = Field(None, description="출금가능금액")
+    repl_amt: Optional[str] = Field(None, description="대용금평가금액")
+    bncr_buy_alowa: Optional[str] = Field(None, description="수익증권매수가능금액")
+    d1_entra: Optional[str] = Field(None, description="d+1추정예수금")
+    d2_entra: Optional[str] = Field(None, description="d+2추정예수금")
+    crd_set_grnta: Optional[str] = Field(None, description="신용설정평가금")
 
 
 class AssetEvaluation(BaseModel):


### PR DESCRIPTION
Fixes #1 
1. **DepositDetail 모델 수정**: kt00001 API의 실제 응답 필드명(`entr`, `ord_alow_amt` 등)에 맞게 수정
2. **`get_account_balance` 메서드 수정**: 새로운 필드명을 사용하도록 수정하고, 총잔고를 예수금+대용금으로 계산

상황을 정리하면:

1. **`easy_api.py`의 `Account` 클래스**가 `self._client.get_account_balance()`를 호출하고 있었습니다
2. **하지만 `client.py`의 `KiwoomClient` 클래스**에는 그런 메서드가 없었습니다
4. 그래서 처음에 `'KiwoomClient' object has no attribute 'get_account_balance'` 에러가 발생했습니다

제가 한 작업:
- `KiwoomClient` 클래스에 `get_account_balance` 메서드를 **새로 추가**
- 이 메서드는 기존의 `get_deposit_details()`를 호출해서 데이터를 가져온 후, `AccountBalance` 객체로 변환해서 반환